### PR TITLE
IntelHexReader: Call HandleAddress() in all Read() methods.

### DIFF
--- a/Src/HexIO/IntelHexReader.cs
+++ b/Src/HexIO/IntelHexReader.cs
@@ -91,8 +91,20 @@ namespace HexIO
         /// <returns>true if there are more records available or false of end of file</returns>
         public bool Read(out IntelHexRecord hexRecord)
         {
+            return Read(out hexRecord, out _);
+        }
+
+        /// <summary>
+        ///     Read a <see cref="IntelHexRecord"/> from the stream
+        /// </summary>
+        /// <param name="hexRecord">The hex record.</param>
+        /// <param name="address">The start address for the record.</param>
+        /// <returns>true if there are more records available or false of end of file</returns>
+        public bool Read(out IntelHexRecord hexRecord, out uint address)
+        {
             var result = false;
             hexRecord = null;
+            address = 0;
 
             var hexLine = _streamReader.ReadLine();
 
@@ -100,6 +112,11 @@ namespace HexIO
             {
                 hexRecord = hexLine.ParseHexRecord();
 
+                if(hexRecord.RecordType != IntelHexRecordType.EndOfFile) 
+                { 
+                    address = HandleAddress(hexRecord); 
+                }
+                
                 result = true;
             }
 

--- a/Src/HexIOTests/IntelHexReaderTests.cs
+++ b/Src/HexIOTests/IntelHexReaderTests.cs
@@ -54,7 +54,7 @@ namespace HexIOTests
         public void TestReadOnEmptyStream()
         {
             var intelHexReader = new IntelHexReader(new MemoryStream());
-            var result = intelHexReader.Read(out _, out _);
+            var result = intelHexReader.Read(out uint _, out _);
 
             result.Should().Be(false);
         }


### PR DESCRIPTION
- Also call `HandleAddress()` in the `Read(IntelHexRecord)` method, so that `_addressBase` is correctly updated if both `Read()` methods  are used.
- Added method overload to get the raw `IntelHexRecord` and the `address` value.