### PR TITLE
Stacking files with GUID names and .transformed extension has issues with some hex editors.

### DIFF
--- a/HexIO/IntelHexStreamTransformer.cs
+++ b/HexIO/IntelHexStreamTransformer.cs
@@ -84,7 +84,7 @@ namespace HexIO
                 throw new FileNotFoundException(Resources.FileNotFound, inputFile);
             }
 
-            string tempFileNameOld = null
+            string tempFileNameOld = null;
             string tempFileName = null;
             string sourceFileName = inputFile;
             string path = Path.GetDirectoryName(inputFile);

--- a/HexIO/IntelHexStreamTransformer.cs
+++ b/HexIO/IntelHexStreamTransformer.cs
@@ -84,12 +84,18 @@ namespace HexIO
                 throw new FileNotFoundException(Resources.FileNotFound, inputFile);
             }
 
+            string tempFileNameOld = null
             string tempFileName = null;
             string sourceFileName = inputFile;
             string path = Path.GetDirectoryName(inputFile);
 
             transforms.ToList().ForEach(transform =>
             {
+                if (tempFileName != null)
+                {
+                    tempFileNameOld = tempFileName;
+                }
+
                 tempFileName = Path.Combine(path, Guid.NewGuid().ToString());
 
                 using (StreamWriter streamWriter = _fileSystem.CreateText(tempFileName))
@@ -112,10 +118,15 @@ namespace HexIO
                     }
                 }
 
+                if (tempFileNameOld != null)
+                {
+                    _fileSystem.Delete(tempFileNameOld);
+                }
+
                 sourceFileName = tempFileName;
             });
 
-            var transformedFileName = Path.Combine(path, $"{inputFile}.transformed");
+            var transformedFileName = Path.Combine(path, $"{Path.GetFileNameWithoutExtension(inputFile)}_transformed.hex");
 
             if(_fileSystem.Exists(transformedFileName))
             {


### PR DESCRIPTION
Hello, 
Huge thanks for the project, it helped me to automate the editing of my .hex file.

I noticed that when you do several ModificationTransforms temporary files are stacking in the file directory, which you have to remove later manually, I suggest memorizing previous tempFileName and later removing it using _fileSystem.

Also, I noticed that some editors have issues decoding files that have non .hex extension. They choose depending on it how to decode file. So I suggest to change the output file name.